### PR TITLE
refactor: apply @get:Schema to DTO properties

### DIFF
--- a/src/main/kotlin/com/example/workflow/feature/account/model/RegisterAccountRequest.kt
+++ b/src/main/kotlin/com/example/workflow/feature/account/model/RegisterAccountRequest.kt
@@ -7,14 +7,14 @@ import jakarta.validation.constraints.NotBlank
 data class RegisterAccountRequest(
     @field:NotBlank(message = "Email address must not be blank")
     @field:Email(message = "Invalid email address format")
-    @Schema(
+    @get:Schema(
         description = "your email address",
         example = "user@example.com",
     )
     val emailAddress: String,
 
     @field:NotBlank(message = "password must not be blank")
-    @Schema(
+    @get:Schema(
         description = "Your account password",
         example = "P4sSw0rd!",
     )

--- a/src/main/kotlin/com/example/workflow/feature/account/model/UpdateAccountRequest.kt
+++ b/src/main/kotlin/com/example/workflow/feature/account/model/UpdateAccountRequest.kt
@@ -5,14 +5,14 @@ import jakarta.validation.constraints.Email
 
 data class UpdateAccountRequest(
     @field:Email(message = "Invalid email address format")
-    @Schema(
+    @get:Schema(
         description = "your email address",
         example = "user@example.com",
         required = false,
     )
     val emailAddress: String? = null,
 
-    @Schema(
+    @get:Schema(
         description = "Your account password",
         example = "P4sSw0rd!",
         required = false,

--- a/src/test/kotlin/com/example/workflow/unit/feature/account/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/account/service/AccountServiceTest.kt
@@ -34,16 +34,6 @@ class AccountServiceTest {
 
     @Nested
     inner class SaveAccount {
-        @BeforeEach
-        fun setUp() {
-            mockkStatic(Account::toViewDto)
-        }
-
-        @AfterEach
-        fun tearDown() {
-            unmockkStatic(Account::toViewDto)
-        }
-
         @Test
         fun `returns account when creating a new account`() {
             // Arrange


### PR DESCRIPTION
This merge introduces the following changes:

- Springdoc-openapi
  - Ensured that OpenAPI schema annotations are correctly applied to Kotlin data class properties by targeting the generated getter methods.
- Tests
  - Removed unnecessary code.

