### PR TITLE
 feat(role): implement role management API with getting all roles endpoint

### DIFF
--- a/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
@@ -100,6 +100,11 @@ class RoleController(
                 description = "Authentication credentials are missing or invalid.",
                 content = [Content()]
             ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Required role missing.",
+                content = [Content()]
+            ),
         ],
     )
     @GetMapping

--- a/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
@@ -1,5 +1,6 @@
 package com.example.workflow.feature.role.controller
 
+import com.example.workflow.common.model.UnifiedErrorResponse
 import com.example.workflow.common.path.ApiPath
 import com.example.workflow.feature.role.model.CreateRoleRequest
 import com.example.workflow.feature.role.model.RoleViewListResponse
@@ -26,6 +27,52 @@ class RoleController(
     private val getAllRolesUseCase: GetAllRolesUseCase,
     private val getAllRolesPresenter: GetAllRolesPresenter,
 ) {
+    @Operation(
+        summary = "Create a new role",
+        description = "Creates a new role for the admin user.",
+        requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Role Information",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = CreateRoleRequest::class)
+                )
+            ]
+        ),
+        responses = [
+            ApiResponse(
+                responseCode = "201",
+                description = "Successfully created a role",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = RoleViewResponse::class)
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Invalid request data or a general business validation error occurred. Details are provided in the 'errors' map.",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = UnifiedErrorResponse::class)
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "Authentication credentials are missing or invalid.",
+                content = [Content()]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Required role missing.",
+                content = [Content()]
+            ),
+        ],
+    )
     @PostMapping
     fun createRole(@Valid @RequestBody request: CreateRoleRequest): ResponseEntity<RoleViewResponse> {
         val useCaseResult: CreateRoleUseCase.Result = createRoleUseCase.execute(request)
@@ -33,6 +80,28 @@ class RoleController(
         return ResponseEntity.status(HttpStatus.CREATED).body(presenterResult.response)
     }
 
+    @Operation(
+        summary = "Get all roles",
+        description = "Retrieves all roles for the admin user.",
+        security = [SecurityRequirement(name = "bearer-key")],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Successfully retrieved all roles information",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = RoleViewListResponse::class)
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "Authentication credentials are missing or invalid.",
+                content = [Content()]
+            ),
+        ],
+    )
     @GetMapping
     fun getAllRoles(): ResponseEntity<RoleViewListResponse> {
         val useCaseResult: GetAllRolesUseCase.Result = getAllRolesUseCase.execute()

--- a/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
@@ -2,11 +2,17 @@ package com.example.workflow.feature.role.controller
 
 import com.example.workflow.common.path.ApiPath
 import com.example.workflow.feature.role.model.CreateRoleRequest
+import com.example.workflow.feature.role.model.RoleViewListResponse
 import com.example.workflow.feature.role.model.RoleViewResponse
 import com.example.workflow.feature.role.presenter.CreateRolePresenter
 import com.example.workflow.feature.role.presenter.GetAllRolesPresenter
 import com.example.workflow.feature.role.usecase.CreateRoleUseCase
 import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -28,7 +34,7 @@ class RoleController(
     }
 
     @GetMapping
-    fun getAllRoles(): ResponseEntity<List<RoleViewResponse>> {
+    fun getAllRoles(): ResponseEntity<RoleViewListResponse> {
         val useCaseResult: GetAllRolesUseCase.Result = getAllRolesUseCase.execute()
         val presenterResult: GetAllRolesPresenter.Result = getAllRolesPresenter.toResponse(useCaseResult)
         return ResponseEntity.status(HttpStatus.OK).body(presenterResult.response)

--- a/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/controller/RoleController.kt
@@ -4,25 +4,33 @@ import com.example.workflow.common.path.ApiPath
 import com.example.workflow.feature.role.model.CreateRoleRequest
 import com.example.workflow.feature.role.model.RoleViewResponse
 import com.example.workflow.feature.role.presenter.CreateRolePresenter
+import com.example.workflow.feature.role.presenter.GetAllRolesPresenter
 import com.example.workflow.feature.role.usecase.CreateRoleUseCase
+import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping(ApiPath.Role.BASE)
 class RoleController(
     private val createRoleUseCase: CreateRoleUseCase,
     private val createRolePresenter: CreateRolePresenter,
+    private val getAllRolesUseCase: GetAllRolesUseCase,
+    private val getAllRolesPresenter: GetAllRolesPresenter,
 ) {
     @PostMapping
     fun createRole(@Valid @RequestBody request: CreateRoleRequest): ResponseEntity<RoleViewResponse> {
         val useCaseResult: CreateRoleUseCase.Result = createRoleUseCase.execute(request)
         val presenterResult: CreateRolePresenter.Result = createRolePresenter.toResponse(useCaseResult)
         return ResponseEntity.status(HttpStatus.CREATED).body(presenterResult.response)
+    }
+
+    @GetMapping
+    fun getAllRoles(): ResponseEntity<List<RoleViewResponse>> {
+        val useCaseResult: GetAllRolesUseCase.Result = getAllRolesUseCase.execute()
+        val presenterResult: GetAllRolesPresenter.Result = getAllRolesPresenter.toResponse(useCaseResult)
+        return ResponseEntity.status(HttpStatus.OK).body(presenterResult.response)
     }
 }

--- a/src/main/kotlin/com/example/workflow/feature/role/model/RoleViewListResponse.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/model/RoleViewListResponse.kt
@@ -1,5 +1,22 @@
 package com.example.workflow.feature.role.model
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class RoleViewListResponse(
+    @get:Schema(
+        description = "role list",
+        example = """
+            "roles": [
+                {
+                    "id": "58196e4f-62cf-4a89-817e-d54116a78a43",
+                    "name": "EXAMPLE_USER",
+                },
+                {
+                    "id": "9bffdd2e-0f25-4032-ab31-ab390192e283",
+                    "name": "EXAMPLE_ADMIN",
+                }
+            ]
+        """,
+    )
     val roles: List<RoleViewResponse>
 )

--- a/src/main/kotlin/com/example/workflow/feature/role/model/RoleViewListResponse.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/model/RoleViewListResponse.kt
@@ -1,0 +1,5 @@
+package com.example.workflow.feature.role.model
+
+data class RoleViewListResponse(
+    val roles: List<RoleViewResponse>
+)

--- a/src/main/kotlin/com/example/workflow/feature/role/model/RoleViewResponse.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/model/RoleViewResponse.kt
@@ -1,8 +1,18 @@
 package com.example.workflow.feature.role.model
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
 data class RoleViewResponse(
+    @get:Schema(
+        description = "role id",
+        example = "58196e4f-62cf-4a89-817e-d54116a78a43",
+    )
     val id: UUID,
+
+    @get:Schema(
+        description = "role name",
+        example = "EXAMPLE_USER",
+    )
     val name: String,
 )

--- a/src/main/kotlin/com/example/workflow/feature/role/presenter/GetAllRolesPresenter.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/presenter/GetAllRolesPresenter.kt
@@ -1,6 +1,6 @@
 package com.example.workflow.feature.role.presenter
 
-import com.example.workflow.feature.role.model.RoleViewResponse
+import com.example.workflow.feature.role.model.RoleViewListResponse
 import com.example.workflow.feature.role.model.toViewResponse
 import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
 import org.springframework.stereotype.Component
@@ -8,11 +8,13 @@ import org.springframework.stereotype.Component
 @Component
 class GetAllRolesPresenter {
     data class Result(
-        val response: List<RoleViewResponse>
+        val response: RoleViewListResponse
     )
 
     fun toResponse(useCaseResult: GetAllRolesUseCase.Result): Result {
-        val roleViewResponseList: List<RoleViewResponse> = useCaseResult.roleViewDtoList.map { it.toViewResponse() }
+        val roleViewResponseList = RoleViewListResponse(
+            roles = useCaseResult.roleViewDtoList.map { it.toViewResponse() }
+        )
         return Result(
             response = roleViewResponseList
         )

--- a/src/main/kotlin/com/example/workflow/feature/role/presenter/GetAllRolesPresenter.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/presenter/GetAllRolesPresenter.kt
@@ -1,0 +1,20 @@
+package com.example.workflow.feature.role.presenter
+
+import com.example.workflow.feature.role.model.RoleViewResponse
+import com.example.workflow.feature.role.model.toViewResponse
+import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
+import org.springframework.stereotype.Component
+
+@Component
+class GetAllRolesPresenter {
+    data class Result(
+        val response: List<RoleViewResponse>
+    )
+
+    fun toResponse(useCaseResult: GetAllRolesUseCase.Result): Result {
+        val roleViewResponseList: List<RoleViewResponse> = useCaseResult.roleViewDtoList.map { it.toViewResponse() }
+        return Result(
+            response = roleViewResponseList
+        )
+    }
+}

--- a/src/main/kotlin/com/example/workflow/feature/role/service/RoleService.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/service/RoleService.kt
@@ -16,6 +16,11 @@ class RoleService(
     }
 
     @Transactional
+    fun getAllRoles(): List<Role> {
+        return roleRepository.findAll()
+    }
+
+    @Transactional
     fun verifyRoleAvailability(name: String) {
         if (roleRepository.findByName(name) != null) {
             throw RoleNameAlreadyCreatedException()

--- a/src/main/kotlin/com/example/workflow/feature/role/usecase/GetAllRolesUseCase.kt
+++ b/src/main/kotlin/com/example/workflow/feature/role/usecase/GetAllRolesUseCase.kt
@@ -1,0 +1,24 @@
+package com.example.workflow.feature.role.usecase
+
+import com.example.workflow.core.role.Role
+import com.example.workflow.core.role.toViewDto
+import com.example.workflow.feature.role.model.RoleViewDto
+import com.example.workflow.feature.role.service.RoleService
+import org.springframework.stereotype.Service
+
+@Service
+class GetAllRolesUseCase(
+    private val roleService: RoleService,
+) {
+    data class Result(
+        val roleViewDtoList: List<RoleViewDto>
+    )
+
+    fun execute(): Result {
+        val roles: List<Role> = roleService.getAllRoles()
+        val roleViewDtoList: List<RoleViewDto> = roles.map { it.toViewDto() }
+        return Result(
+            roleViewDtoList = roleViewDtoList,
+        )
+    }
+}

--- a/src/main/kotlin/com/example/workflow/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/workflow/infra/security/config/SecurityConfig.kt
@@ -64,6 +64,7 @@ class SecurityConfig(private val rsaKeyProperties: RsaKeyProperties) {
                     ApiPath.Role.BASE,
                     hasRole(Role.ADMIN.name)
                 )
+                authorize(HttpMethod.GET, ApiPath.Role.BASE, hasRole(Role.ADMIN.name))
                 // Token
                 authorize(
                     HttpMethod.POST,

--- a/src/test/kotlin/com/example/workflow/e2e/feature/role/RoleApiTest.kt
+++ b/src/test/kotlin/com/example/workflow/e2e/feature/role/RoleApiTest.kt
@@ -154,4 +154,76 @@ class RoleApiTest : AbstractE2ETest() {
             assertNull(response.body)
         }
     }
+
+    @Nested
+    inner class GetAllRoles {
+        @Test
+        fun `GET request with a admin role should return 200 OK`() {
+            // Arrange
+            val authResult: E2ETestRestTemplate.AuthResult = restTemplate.authenticateWithAdmin()
+
+            // Act
+            val response = restTemplate.get(
+                responseType = String::class.java,
+                path = ApiPath.Role.BASE,
+                accessToken = authResult.accessToken,
+            )
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertNotNull(response.body)
+            val mapper = jacksonObjectMapper()
+            val expectedBody = mapper.readTree(
+                """
+                    {
+                        "roles":[
+                            {
+                                "id":"7189ff37-21e6-4ee5-a8c5-83282e3e1de1",
+                                "name":"USER"
+                            },
+                            {
+                                "id":"3c21a2e0-7594-45bf-8eb3-6bf9edbed13d",
+                                "name":"ADMIN"
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+            val actualBody = mapper.readTree(response.body)
+            assertEquals(expectedBody, actualBody)
+        }
+
+        @Test
+        fun `GET request with invalid credentials should return 401 Unauthorized`() {
+            // Arrange
+
+            // Act
+            val response = restTemplate.get(
+                responseType = String::class.java,
+                path = ApiPath.Role.BASE,
+                accessToken = "invalid-access-token",
+            )
+
+            // Assert
+            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertNull(response.body)
+        }
+
+        @Test
+        fun `GET request for a non-admin role should return 403 Forbidden`() {
+            // Arrange
+            val authResult: E2ETestRestTemplate.AuthResult = restTemplate.registerAccountAndAuthenticate()
+
+            // Act
+            val response = restTemplate.get(
+                responseType = String::class.java,
+                path = ApiPath.Role.BASE,
+                accessToken = authResult.accessToken,
+            )
+
+            // Assert
+            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+            assertNull(response.body)
+        }
+    }
 }

--- a/src/test/kotlin/com/example/workflow/e2e/feature/role/RoleApiTest.kt
+++ b/src/test/kotlin/com/example/workflow/e2e/feature/role/RoleApiTest.kt
@@ -11,10 +11,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
-import kotlin.test.fail
+import kotlin.test.*
 
 @E2ETest
 class RoleApiTest : AbstractE2ETest() {
@@ -106,6 +103,55 @@ class RoleApiTest : AbstractE2ETest() {
                 """
             )
             assertEquals(expectedBody, actualBody)
+        }
+
+        @Test
+        fun `POST request with invalid credentials returns 401 Unauthorized`() {
+            // Arrange
+
+            // Act
+            val json = """
+                {
+                    "name": "NEW_ADMIN"
+                }
+            """.trimIndent()
+
+            // Act
+            val response = restTemplate.post(
+                responseType = String::class.java,
+                path = ApiPath.Role.BASE,
+                body = json,
+                accessToken = "invalid-access-token",
+            )
+
+            // Assert
+            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertNull(response.body)
+        }
+
+        @Test
+        fun `POST request with invalid credentials returns 403 Forbidden`() {
+            // Arrange
+            val authResult: E2ETestRestTemplate.AuthResult = restTemplate.registerAccountAndAuthenticate()
+
+            // Act
+            val json = """
+                {
+                    "name": "ADMIN"
+                }
+            """.trimIndent()
+
+            // Act
+            val response = restTemplate.post(
+                responseType = String::class.java,
+                path = ApiPath.Role.BASE,
+                body = json,
+                accessToken = authResult.accessToken,
+            )
+
+            // Assert
+            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+            assertNull(response.body)
         }
     }
 }

--- a/src/test/kotlin/com/example/workflow/e2e/feature/role/RoleApiTest.kt
+++ b/src/test/kotlin/com/example/workflow/e2e/feature/role/RoleApiTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 import kotlin.test.*
 
@@ -21,6 +22,7 @@ class RoleApiTest : AbstractE2ETest() {
     @Nested
     inner class CreateRole {
         @Test
+        @Transactional
         fun `POST valid request returns 201 Created`() {
             // Arrange
             val authResult: E2ETestRestTemplate.AuthResult = restTemplate.authenticateWithAdmin()

--- a/src/test/kotlin/com/example/workflow/e2e/test/base/AbstractE2ETest.kt
+++ b/src/test/kotlin/com/example/workflow/e2e/test/base/AbstractE2ETest.kt
@@ -1,15 +1,19 @@
 package com.example.workflow.e2e.test.base
 
+import com.example.workflow.e2e.test.config.DbCleanupListener
 import com.example.workflow.e2e.test.config.E2ETestConfig
 import com.example.workflow.e2e.test.config.TestcontainersConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.test.context.TestExecutionListeners
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestExecutionListeners(
+    listeners = [DbCleanupListener::class],
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
 @Import(TestcontainersConfiguration::class, E2ETestConfig::class)
 @ActiveProfiles("test")
-@Transactional
 abstract class AbstractE2ETest {
 }

--- a/src/test/kotlin/com/example/workflow/e2e/test/config/DbCleanupListener.kt
+++ b/src/test/kotlin/com/example/workflow/e2e/test/config/DbCleanupListener.kt
@@ -1,0 +1,21 @@
+package com.example.workflow.e2e.test.config
+
+import org.springframework.test.context.TestContext
+import org.springframework.test.context.TestExecutionListener
+import javax.sql.DataSource
+
+class DbCleanupListener : TestExecutionListener {
+    override fun beforeTestMethod(testContext: TestContext) {
+        val dataSource = testContext.applicationContext.getBean(DataSource::class.java)
+        val sql = javaClass.getResource("/db/init-test-data.sql")!!.readText()
+        dataSource.connection.use { connection ->
+            val stmt = connection.createStatement()
+            for (statement in sql.split(";")) {
+                val trimmed = statement.trim()
+                if (trimmed.isNotEmpty()) {
+                    stmt.execute(trimmed)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/workflow/e2e/test/config/TestDataInitializer.kt
+++ b/src/test/kotlin/com/example/workflow/e2e/test/config/TestDataInitializer.kt
@@ -1,0 +1,26 @@
+package com.example.workflow.e2e.test.config
+
+import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import javax.sql.DataSource
+
+@Configuration
+@Profile("test")
+class TestDataInitializer(
+    private val dataSource: DataSource
+) {
+    @PostConstruct
+    fun init() {
+        val sql = javaClass.getResource("/db/init-test-data.sql")!!.readText()
+        dataSource.connection.use { connection ->
+            val stmt = connection.createStatement()
+            for (statement in sql.split(";")) {
+                val trimmed = statement.trim()
+                if (trimmed.isNotEmpty()) {
+                    stmt.execute(trimmed)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/workflow/integration/core/role/RoleRepositoryTest.kt
+++ b/src/test/kotlin/com/example/workflow/integration/core/role/RoleRepositoryTest.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @IntegrationTest
 @DataJpaTest
@@ -86,6 +87,38 @@ class RoleRepositoryTest {
 
             // Assert
             assertNull(actual)
+        }
+    }
+
+    @Nested
+    inner class FindAll {
+        @Test
+        fun `returns empty list when role does not exist`() {
+            // Arrange
+
+            // Act
+            val actual: List<Role> = roleRepository.findAll()
+
+            // Assert
+            assertTrue(actual.isEmpty())
+        }
+
+        @Test
+        fun `returns roles when two roles exists`() {
+            // Arrange
+            val roles: List<Role> = listOf(
+                TestDataFactory.createRole(name = "EXAMPLE1"),
+                TestDataFactory.createRole(name = "EXAMPLE2"),
+            )
+            roles.forEach { entityManager.persist(it) }
+            entityManager.flush()
+            entityManager.clear()
+
+            // Act
+            val actual: List<Role> = roleRepository.findAll()
+
+            // Assert
+            assertEquals(roles.sortedBy { it.id }, actual.sortedBy { it.id })
         }
     }
 }

--- a/src/test/kotlin/com/example/workflow/integration/test/controller/SecurityConfigTestController.kt
+++ b/src/test/kotlin/com/example/workflow/integration/test/controller/SecurityConfigTestController.kt
@@ -16,6 +16,8 @@ class SecurityConfigTestController {
             ApiPath.SpringDoc.SWAGGER_UI_ALL,
             // Account
             "${ApiPath.Account.BASE}${ApiPath.Account.ME}",
+            // Role
+            ApiPath.Role.BASE,
         ]
     )
     fun get() = ResponseEntity.ok("get")

--- a/src/test/kotlin/com/example/workflow/integration/test/path/HasAdminPathsProvider.kt
+++ b/src/test/kotlin/com/example/workflow/integration/test/path/HasAdminPathsProvider.kt
@@ -10,5 +10,6 @@ class HasAdminPathsProvider : ArgumentsProvider {
     override fun provideArguments(context: ExtensionContext?): Stream<out Arguments?>? = Stream.of(
         // Role
         Arguments.of(HttpMethod.POST, "/v1/roles"),
+        Arguments.of(HttpMethod.GET, "/v1/roles")
     )
 }

--- a/src/test/kotlin/com/example/workflow/unit/core/role/RoleTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/core/role/RoleTest.kt
@@ -1,0 +1,41 @@
+package com.example.workflow.unit.core.role
+
+import com.example.workflow.core.role.Role
+import com.example.workflow.core.role.toViewDto
+import com.example.workflow.support.annotation.UnitTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+import kotlin.test.assertEquals
+
+@UnitTest
+class RoleTest {
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Nested
+    inner class ToViewDto {
+        @Test
+        fun `should map role view dto`() {
+            // Arrange
+            val role = Role(
+                id = UUID.randomUUID(),
+                name = "EXAMPLE",
+            )
+
+            // Act
+            val actual = role.toViewDto()
+
+            // Assert
+            assertEquals(role.id, actual.id)
+            assertEquals(role.name, actual.name)
+        }
+    }
+}

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/controller/RoleControllerTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/controller/RoleControllerTest.kt
@@ -2,6 +2,7 @@ package com.example.workflow.unit.feature.role.controller
 
 import com.example.workflow.feature.role.controller.RoleController
 import com.example.workflow.feature.role.model.CreateRoleRequest
+import com.example.workflow.feature.role.model.RoleViewListResponse
 import com.example.workflow.feature.role.model.RoleViewResponse
 import com.example.workflow.feature.role.presenter.CreateRolePresenter
 import com.example.workflow.feature.role.presenter.GetAllRolesPresenter
@@ -76,7 +77,7 @@ class RoleControllerTest {
             // Arrange
             val useCaseResult: GetAllRolesUseCase.Result = mockk()
             val presenterResult: GetAllRolesPresenter.Result = mockk()
-            val response: List<RoleViewResponse> = mockk()
+            val response: RoleViewListResponse = mockk()
 
             every { presenterResult.response } returns response
             every { getAllRolesUseCase.execute() } returns useCaseResult

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/controller/RoleControllerTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/controller/RoleControllerTest.kt
@@ -4,7 +4,9 @@ import com.example.workflow.feature.role.controller.RoleController
 import com.example.workflow.feature.role.model.CreateRoleRequest
 import com.example.workflow.feature.role.model.RoleViewResponse
 import com.example.workflow.feature.role.presenter.CreateRolePresenter
+import com.example.workflow.feature.role.presenter.GetAllRolesPresenter
 import com.example.workflow.feature.role.usecase.CreateRoleUseCase
+import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
 import com.example.workflow.support.annotation.UnitTest
 import io.mockk.every
 import io.mockk.mockk
@@ -19,15 +21,21 @@ import kotlin.test.assertEquals
 class RoleControllerTest {
     private lateinit var createRoleUseCase: CreateRoleUseCase
     private lateinit var createRolePresenter: CreateRolePresenter
+    private lateinit var getAllRolesUseCase: GetAllRolesUseCase
+    private lateinit var getAllRolesPresenter: GetAllRolesPresenter
     private lateinit var roleController: RoleController
 
     @BeforeEach
     fun setUp() {
         createRoleUseCase = mockk()
         createRolePresenter = mockk()
+        getAllRolesUseCase = mockk()
+        getAllRolesPresenter = mockk()
         roleController = RoleController(
             createRoleUseCase = createRoleUseCase,
             createRolePresenter = createRolePresenter,
+            getAllRolesUseCase = getAllRolesUseCase,
+            getAllRolesPresenter = getAllRolesPresenter,
         )
     }
 
@@ -58,6 +66,28 @@ class RoleControllerTest {
             // Assert
             assertEquals(HttpStatus.CREATED, actual.statusCode)
             assertEquals(roleViewResponse, actual.body)
+        }
+    }
+
+    @Nested
+    inner class GetAllRoles() {
+        @Test
+        fun `should return role view response list`() {
+            // Arrange
+            val useCaseResult: GetAllRolesUseCase.Result = mockk()
+            val presenterResult: GetAllRolesPresenter.Result = mockk()
+            val response: List<RoleViewResponse> = mockk()
+
+            every { presenterResult.response } returns response
+            every { getAllRolesUseCase.execute() } returns useCaseResult
+            every { getAllRolesPresenter.toResponse(useCaseResult) } returns presenterResult
+
+            // Act
+            val actual = roleController.getAllRoles()
+
+            // Assert
+            assertEquals(HttpStatus.OK, actual.statusCode)
+            assertEquals(response, actual.body)
         }
     }
 }

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/model/RoleViewDtoTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/model/RoleViewDtoTest.kt
@@ -1,0 +1,41 @@
+package com.example.workflow.unit.feature.role.model
+
+import com.example.workflow.feature.role.model.RoleViewDto
+import com.example.workflow.feature.role.model.toViewResponse
+import com.example.workflow.support.annotation.UnitTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+import kotlin.test.assertEquals
+
+@UnitTest
+class RoleViewDtoTest {
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Nested
+    inner class ToViewResponse {
+        @Test
+        fun `should map role view response`() {
+            // Arrange
+            val roleViewDto = RoleViewDto(
+                id = UUID.randomUUID(),
+                name = "EXAMPLE",
+            )
+
+            // Act
+            val actual = roleViewDto.toViewResponse()
+
+            // Assert
+            assertEquals(roleViewDto.id, actual.id)
+            assertEquals(roleViewDto.name, actual.name)
+        }
+    }
+}

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/presenter/GetAllRolesPresenterTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/presenter/GetAllRolesPresenterTest.kt
@@ -59,8 +59,8 @@ class GetAllRolesPresenterTest {
             val actual: GetAllRolesPresenter.Result = getAllRolePresenter.toResponse(useCaseResult)
 
             // Assert
-            assertEquals(roleViewResponse0, actual.response[0])
-            assertEquals(roleViewResponse1, actual.response[1])
+            assertEquals(roleViewResponse0, actual.response.roles[0])
+            assertEquals(roleViewResponse1, actual.response.roles[1])
         }
 
         @Test
@@ -75,7 +75,7 @@ class GetAllRolesPresenterTest {
             val actual: GetAllRolesPresenter.Result = getAllRolePresenter.toResponse(useCaseResult)
 
             // Assert
-            assertTrue(actual.response.isEmpty())
+            assertTrue(actual.response.roles.isEmpty())
         }
     }
 }

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/presenter/GetAllRolesPresenterTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/presenter/GetAllRolesPresenterTest.kt
@@ -1,0 +1,81 @@
+package com.example.workflow.unit.feature.role.presenter
+
+import com.example.workflow.feature.role.model.RoleViewDto
+import com.example.workflow.feature.role.model.RoleViewResponse
+import com.example.workflow.feature.role.model.toViewResponse
+import com.example.workflow.feature.role.presenter.GetAllRolesPresenter
+import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
+import com.example.workflow.support.annotation.UnitTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@UnitTest
+class GetAllRolesPresenterTest {
+    private lateinit var getAllRolePresenter: GetAllRolesPresenter
+
+    @BeforeEach
+    fun setUp() {
+        getAllRolePresenter = GetAllRolesPresenter()
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Nested
+    inner class ToResponse {
+        @BeforeEach
+        fun setUp() {
+            mockkStatic(RoleViewDto::toViewResponse)
+        }
+
+        @AfterEach
+        fun tearDown() {
+            unmockkStatic(RoleViewDto::toViewResponse)
+        }
+
+        @Test
+        fun `should return Presenter result of all roles list when multiple roles exist`() {
+            // Arrange
+            val roleViewDtoList: List<RoleViewDto> = listOf(mockk(), mockk())
+            val useCaseResult = GetAllRolesUseCase.Result(
+                roleViewDtoList = roleViewDtoList,
+            )
+            val roleViewResponse0: RoleViewResponse = mockk()
+            val roleViewResponse1: RoleViewResponse = mockk()
+
+            every { roleViewDtoList[0].toViewResponse() } returns roleViewResponse0
+            every { roleViewDtoList[1].toViewResponse() } returns roleViewResponse1
+
+            // Act
+            val actual: GetAllRolesPresenter.Result = getAllRolePresenter.toResponse(useCaseResult)
+
+            // Assert
+            assertEquals(roleViewResponse0, actual.response[0])
+            assertEquals(roleViewResponse1, actual.response[1])
+        }
+
+        @Test
+        fun `should return Presenter result of an empty list when no roles exist`() {
+            // Arrange
+            val roleViewDtoList: List<RoleViewDto> = listOf()
+            val useCaseResult = GetAllRolesUseCase.Result(
+                roleViewDtoList = roleViewDtoList,
+            )
+
+            // Act
+            val actual: GetAllRolesPresenter.Result = getAllRolePresenter.toResponse(useCaseResult)
+
+            // Assert
+            assertTrue(actual.response.isEmpty())
+        }
+    }
+}

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/service/RoleServiceTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/service/RoleServiceTest.kt
@@ -45,6 +45,23 @@ class RoleServiceTest {
     }
 
     @Nested
+    inner class GetAllRoles {
+        @Test
+        fun `should return a list of all roles`() {
+            // Arrange
+            val roles: List<Role> = mockk()
+
+            every { roleRepository.findAll() } returns roles
+
+            // Act
+            val actual = roleService.getAllRoles()
+
+            // Assert
+            assertEquals(roles, actual)
+        }
+    }
+
+    @Nested
     inner class VerifyRoleAvailability {
         @Test
         fun `throws RoleNameAlreadyCreatedException when email address is created`() {

--- a/src/test/kotlin/com/example/workflow/unit/feature/role/usecase/GetAllRolesUseCaseTest.kt
+++ b/src/test/kotlin/com/example/workflow/unit/feature/role/usecase/GetAllRolesUseCaseTest.kt
@@ -1,0 +1,82 @@
+package com.example.workflow.unit.feature.role.usecase
+
+import com.example.workflow.core.role.Role
+import com.example.workflow.core.role.toViewDto
+import com.example.workflow.feature.role.model.RoleViewDto
+import com.example.workflow.feature.role.service.RoleService
+import com.example.workflow.feature.role.usecase.GetAllRolesUseCase
+import com.example.workflow.support.annotation.UnitTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@UnitTest
+class GetAllRolesUseCaseTest {
+    private lateinit var roleService: RoleService
+    private lateinit var getAllRolesUseCase: GetAllRolesUseCase
+
+    @BeforeEach
+    fun setUp() {
+        roleService = mockk()
+        getAllRolesUseCase = GetAllRolesUseCase(
+            roleService = roleService
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Nested
+    inner class ExecuteFunction() {
+        @BeforeEach
+        fun setUp() {
+            mockkStatic(Role::toViewDto)
+        }
+
+        @AfterEach
+        fun tearDown() {
+            unmockkStatic(Role::toViewDto)
+        }
+
+        @Test
+        fun `should return UseCase result of all roles list when multiple roles exist`() {
+            // Arrange
+            val roles: List<Role> = listOf(mockk(), mockk())
+            val roleViewDto0: RoleViewDto = mockk()
+            val roleViewDto1: RoleViewDto = mockk()
+
+            every { roleService.getAllRoles() } returns roles
+            every { roles[0].toViewDto() } returns roleViewDto0
+            every { roles[1].toViewDto() } returns roleViewDto1
+
+            // Act
+            val actual = getAllRolesUseCase.execute()
+
+            // Assert
+            assertEquals(roleViewDto0, actual.roleViewDtoList[0])
+            assertEquals(roleViewDto1, actual.roleViewDtoList[1])
+        }
+
+        @Test
+        fun `should return UseCase result of an empty list when no roles exist`() {
+            // Arrange
+            val roles: List<Role> = listOf()
+
+            every { roleService.getAllRoles() } returns roles
+
+            // Act
+            val actual = getAllRolesUseCase.execute()
+
+            // Assert
+            assertTrue(actual.roleViewDtoList.isEmpty())
+        }
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -4,11 +4,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    defer-datasource-initialization: true
+    defer-datasource-initialization: false
   sql:
     init:
-      mode: always
-      data-locations: classpath:db/test-data.sql
+      mode: never
 rsa:
   private-key: classpath:certs/test-private.pem
   public-key: classpath:certs/test-public.pem

--- a/src/test/resources/db/init-test-data.sql
+++ b/src/test/resources/db/init-test-data.sql
@@ -1,3 +1,8 @@
+delete from account_role;
+delete from refresh_token;
+delete from role;
+delete from account;
+
 insert into account(id, email_address, password) values
   ('15101d3d-0b10-4e5a-aae1-b21ccdf06b34', 'admin@example.com', '$2a$10$Ui1YMe5Zi3zTKElzouyAseR1gaDhrMaEyzNlcMqmpI9nAU.B8IhUe')
 ;


### PR DESCRIPTION
This merge introduces the following changes:

- Implemented role management API with getting all roles endpoint.
- Added annotations for OpenAPI docs.
- Added E2E tests for role creation.
- Changed to reset table data for each test.